### PR TITLE
create css to adjust column width

### DIFF
--- a/src/main/resources/static/css/tableAdjust.css
+++ b/src/main/resources/static/css/tableAdjust.css
@@ -7,7 +7,7 @@
     width: 35%;
   }
 
-  th.question {
+  th.task {
     width: 65%;
   }
 }
@@ -18,7 +18,7 @@
     width: 30%;
   }
 
-  th.question {
+  th.task {
     width: 70%;
   }
 }
@@ -29,7 +29,7 @@
     width: 25%;
   }
 
-  th.question {
+  th.task {
     width: 75%;
   }
 }
@@ -40,7 +40,7 @@
     width: 25%;
   }
 
-  th.question {
+  th.task {
     width: 75%;
   }
 }

--- a/src/main/resources/static/css/tableAdjust.css
+++ b/src/main/resources/static/css/tableAdjust.css
@@ -1,0 +1,46 @@
+/* Extra small devices (portrait phones, less than 576px)
+ No media query since this is the default in Bootstrap */
+
+/* Small devices (landscape phones, 576px and up) */
+@media (min-width: 576px) { 
+  th.contest {
+    width: 35%;
+  }
+
+  th.question {
+    width: 65%;
+  }
+}
+
+/* Medium devices (tablets, 768px and up) */
+@media (min-width: 768px) {
+  th.contest {
+    width: 30%;
+  }
+
+  th.question {
+    width: 70%;
+  }
+}
+
+/* Large devices (desktops, 992px and up) */
+@media (min-width: 992px) {
+  th.contest {
+    width: 25%;
+  }
+
+  th.question {
+    width: 75%;
+  }
+}
+
+/* Extra large devices (large desktops, 1200px and up) */
+@media (min-width: 1200px) {
+  th.contest {
+    width: 25%;
+  }
+
+  th.question {
+    width: 75%;
+  }
+}

--- a/src/main/resources/templates/serp_task.html
+++ b/src/main/resources/templates/serp_task.html
@@ -5,6 +5,7 @@
 	<meta charset="UTF-8"/>
 	<meta name="viewport" content="width=device-width, initial-scale=1"/>
 	<link rel="stylesheet" href="/webjars/bootstrap/3.3.7/css/bootstrap.min.css" />
+	<link href="/css/tableAdjust.css" th:href="@{/css/tableAdjust.css}" rel="stylesheet"></link>
 </head>
 
 <body>
@@ -17,8 +18,8 @@
 		<table class="table table-hover">
 			<thead>
 				<tr>
-					<th>コンテスト</th>
-					<th>問題</th>
+					<th class="contest">コンテスト</th>
+					<th class="question">問題</th>
 				</tr>
 			</thead>
 			<tbody>

--- a/src/main/resources/templates/serp_task.html
+++ b/src/main/resources/templates/serp_task.html
@@ -19,7 +19,7 @@
 			<thead>
 				<tr>
 					<th class="contest">コンテスト</th>
-					<th class="question">問題</th>
+					<th class="task">問題</th>
 				</tr>
 			</thead>
 			<tbody>


### PR DESCRIPTION
- やったこと
  - 要素識別のために表の見出しにクラスを追加。
  - 表調整用のcssを作成。
  - cssをserf_taskで読み込み。
- どうなるか
  - 画面サイズが横576pixel以上の時、表の2列目がちょっとだけ1列目の方に寄ります。だいたい3:7の割合で、見え方が自然になるように調整しました。

※SASS使いたかた